### PR TITLE
refactor: styling advertisement component

### DIFF
--- a/app/components/shared/Advertisement/styles.css
+++ b/app/components/shared/Advertisement/styles.css
@@ -1,7 +1,7 @@
 .pokt-ad {
   position: relative;
   background-repeat: no-repeat;
-  background-position: center bottom;
+  background-position: center;
   background-blend-mode: overlay;
   background-size: cover;
   display: flex;
@@ -39,12 +39,12 @@
 }
 
 .pokt-ad-action {
+  font-size: 0.875rem;
   font-weight: bold;
   padding: 0px 42px;
   background: transparent;
   border: 2px solid var(--color-white-main);
   color: var(--color-white-main);
-  border: "0";
   margin-top: 32px;
   height: 52px;
   min-width: 224px;


### PR DESCRIPTION
Styling the advertisement component to match old portal.

Updated component looks like:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/10237065/180832199-3ef285ef-b94d-4950-be49-fc4929dc3571.png">



Old Portal component looks like:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/10237065/180831024-b692f9ed-fd9d-42be-9d52-1e8ba1a2972f.png">



had to slightly change the background image position to avoid some clipping when we resize the window:
<img width="701" alt="image" src="https://user-images.githubusercontent.com/10237065/180832135-de6a5e68-2da0-41e7-98cd-b6e0cb545e86.png">
