### PR TITLE
Stripe subscription item

### DIFF
--- a/app/routes/api/stripe/webhook.tsx
+++ b/app/routes/api/stripe/webhook.tsx
@@ -55,6 +55,7 @@ export const action: ActionFunction = async ({ request }) => {
               metadata: sessionCompleted.metadata,
             },
           )
+          // there is only ever 1 subscription item in our subscriptions so just grabbing it here
           await stripe.subscriptionItems.update(subscription.items.data[0].id, {
             metadata: sessionCompleted.metadata,
           })


### PR DESCRIPTION
Arash asked to associated the endpoint_id metadata items to the subscriptionItem as well as the subscription to make it easier for him to send stripe the usage records.