### PR TITLE
Add Description to Stripe Subscription

### DIFF
--- a/app/routes/api/stripe/webhook.tsx
+++ b/app/routes/api/stripe/webhook.tsx
@@ -52,6 +52,7 @@ export const action: ActionFunction = async ({ request }) => {
           const subscription = await stripe.subscriptions.update(
             sessionCompleted.subscription,
             {
+              description: `${sessionCompleted.metadata?.endpoint_name}: ${sessionCompleted.metadata?.endpoint_id}`,
               metadata: sessionCompleted.metadata,
             },
           )


### PR DESCRIPTION
The stripe portal just shows multiple subscriptions with the product name. The user is not able to distinguish between subscriptions within their portal. Add description to subscription based on endpoint metadata so that users can tell the difference in the stripe portal.