### PR TITLE
[UI][BILLING] updating billing estimate to factor for the 150,000 free relays

### DIFF
--- a/app/routes/account.$accountId.billing._index/components/BillingEstimateCard/BillingEstimateCard.tsx
+++ b/app/routes/account.$accountId.billing._index/components/BillingEstimateCard/BillingEstimateCard.tsx
@@ -5,6 +5,7 @@ import { Stripe } from "~/models/stripe/stripe.server"
 import TitledCard from "~/components/TitledCard/TitledCard"
 import { dayjs } from "~/utils/dayjs"
 import { formatStripeDate, getStripeAmount } from "~/utils/billingUtils"
+import { FREE_TIER_MONTHLY_RELAY_LIMIT } from "~/utils/planUtils"
 
 export type BillingEstimateCardProps = {
   totalRelays: number
@@ -30,11 +31,11 @@ export const BillingEstimateCard = ({
   }
 
   // Calculate billing estimate using real pricing
-  // First 150,000 relays are free, then $5 per 1M unit
+  // First N relays (Defined in app/utils/planUtils.ts are free, then $5 per 1M unit
   const unitPrice = getUnitPrice()
   let estimatedCost = 0
-  
-  if (totalRelays <= 150_000) {
+
+  if (totalRelays <= FREE_TIER_MONTHLY_RELAY_LIMIT) {
     estimatedCost = 0
   } else {
     // Calculate units for relays above the free tier
@@ -118,10 +119,11 @@ export const BillingEstimateCard = ({
 
         <Text c="dimmed" size="sm">
           Based on {new Intl.NumberFormat().format(totalRelays)} relays this month
-          {totalRelays > 150_000 && (() => {
-            const units = Math.floor(totalRelays / 1_000_000) + 1
-            return ` (${units} units × $${unitPrice}/unit)`
-          })()}
+          {totalRelays > FREE_TIER_MONTHLY_RELAY_LIMIT &&
+            (() => {
+              const units = Math.floor(totalRelays / 1_000_000) + 1
+              return ` (${units} units × $${unitPrice}/unit)`
+            })()}
         </Text>
 
         {discountText && (

--- a/app/routes/account.$accountId.billing._index/components/BillingEstimateCard/BillingEstimateCard.tsx
+++ b/app/routes/account.$accountId.billing._index/components/BillingEstimateCard/BillingEstimateCard.tsx
@@ -30,9 +30,18 @@ export const BillingEstimateCard = ({
   }
 
   // Calculate billing estimate using real pricing
-  const units = Math.floor(totalRelays / 1_000_000) + 1
+  // First 150,000 relays are free, then $5 per 1M unit
   const unitPrice = getUnitPrice()
-  let estimatedCost = units * unitPrice
+  let estimatedCost = 0
+  
+  if (totalRelays <= 150_000) {
+    estimatedCost = 0
+  } else {
+    // Calculate units for relays above the free tier
+    const billableRelays = totalRelays
+    const units = Math.floor(billableRelays / 1_000_000) + 1
+    estimatedCost = units * unitPrice
+  }
 
   // Apply any discounts from subscription or upcoming invoice
   let discountAmount = 0
@@ -79,15 +88,15 @@ export const BillingEstimateCard = ({
   // Get next billing date from subscription or use fallback
   const getNextBillingDate = () => {
     if (upcomingInvoice?.period_end) {
-      return formatStripeDate(upcomingInvoice.period_end, "Do MMM")
+      return formatStripeDate(upcomingInvoice.period_end, "MMMM D, YYYY")
     } else if (
       subscription &&
       "current_period_end" in subscription &&
       subscription.current_period_end
     ) {
-      return formatStripeDate(subscription.current_period_end as number, "Do MMM")
+      return formatStripeDate(subscription.current_period_end as number, "MMMM D, YYYY")
     } else {
-      return `1st ${dayjs().add(1, "month").format("MMM")}`
+      return dayjs().add(1, "month").startOf("month").format("MMMM D, YYYY")
     }
   }
 
@@ -108,8 +117,11 @@ export const BillingEstimateCard = ({
         </Title>
 
         <Text c="dimmed" size="sm">
-          Based on {new Intl.NumberFormat().format(totalRelays)} relays this month (
-          {units} units × ${unitPrice}/unit)
+          Based on {new Intl.NumberFormat().format(totalRelays)} relays this month
+          {totalRelays > 150_000 && (() => {
+            const units = Math.floor(totalRelays / 1_000_000) + 1
+            return ` (${units} units × $${unitPrice}/unit)`
+          })()}
         </Text>
 
         {discountText && (

--- a/app/routes/account.$accountId.billing._index/route.tsx
+++ b/app/routes/account.$accountId.billing._index/route.tsx
@@ -12,7 +12,6 @@ import { dayjs } from "~/utils/dayjs"
 import { getRequiredServerEnvVar } from "~/utils/environment"
 import { requireUser } from "~/utils/user.server"
 
-
 //TODO: Implement historical usage graphs and more insights about overall billing utilization
 export type AccountBillingLoaderData = {
   invoices: Stripe.Invoice[]

--- a/app/routes/account.$accountId.billing/route.tsx
+++ b/app/routes/account.$accountId.billing/route.tsx
@@ -15,6 +15,8 @@ import { seo_title_append } from "~/utils/seo"
 import { requireUser } from "~/utils/user.server"
 import { UsageRecordSummary, InvoiceUsageData } from "~/types/stripe-custom"
 
+//TODO: Figure out how to have anyone who has _ever_ had PLAN_UNLIMITED (has at least 1 invoice)
+// always maintain access to the billing page. 
 export const meta: MetaFunction = () => {
   return [
     {

--- a/app/routes/account.$accountId.billing/route.tsx
+++ b/app/routes/account.$accountId.billing/route.tsx
@@ -16,7 +16,7 @@ import { requireUser } from "~/utils/user.server"
 import { UsageRecordSummary, InvoiceUsageData } from "~/types/stripe-custom"
 
 //TODO: Figure out how to have anyone who has _ever_ had PLAN_UNLIMITED (has at least 1 invoice)
-// always maintain access to the billing page. 
+// always maintain access to the billing page.
 export const meta: MetaFunction = () => {
   return [
     {

--- a/app/utils/planUtils.ts
+++ b/app/utils/planUtils.ts
@@ -1,4 +1,7 @@
 import { PayPlanType } from "~/models/portal/sdk"
+
+// TODO: Implement populating FREE_TIER_MONTHLY_RELAY_LIMIT from Portal DB
+// Currently hardcoded but should be configurable via database
 export const FREE_TIER_MONTHLY_RELAY_LIMIT = 150000
 
 export function isEnterprisePlan(planType: PayPlanType) {


### PR DESCRIPTION
# ● Fix billing estimate logic for free tier and improve date formatting
_This is a followup to #730_ 

- Handle first 150,000 relays as free without showing disclaimer text
- Update next billing date format to "Month Name Day, Year" (e.g., "`January 15, 2024`")
- Simplify billing calculation display for better UX

## TODOs
- https://github.com/buildwithgrove/grove-portal/issues/734
