### PR TITLE
[BUG] fixing bad docs links, removing dead link to logs page

### DIFF
--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -44,11 +44,6 @@ const getAccountRoutes = (
 ): SidebarNavRoute[] => {
   return [
     {
-      to: `/account/${activeAccount?.id}/logs`,
-      label: "Logs",
-      end: true,
-    },
-    {
       to: `/account/${activeAccount?.id}/sandbox`,
       label: "Sandbox",
       end: true,

--- a/app/routes/account.$accountId.$appId._index/components/AppEndpointsTable/AppEndpointsTable.tsx
+++ b/app/routes/account.$accountId.$appId._index/components/AppEndpointsTable/AppEndpointsTable.tsx
@@ -162,7 +162,7 @@ const AppEndpointsTable = ({
                         component="a"
                         href={
                           chain.blockchain
-                            ? `${DOCS_PATH}/service-apis/${chain.blockchain}-api`
+                            ? `${DOCS_PATH}/${chain.blockchain}`
                             : DOCS_PATH
                         }
                         target="_blank"

--- a/app/utils/utils.ts
+++ b/app/utils/utils.ts
@@ -46,4 +46,4 @@ export const groupBy = (array: any[], key: string) => {
 }
 
 export const DISCORD_PATH = "https://discord.gg/build-with-grove"
-export const DOCS_PATH = "https://docs.grove.city"
+export const DOCS_PATH = "https://api.pocket.network/docs"


### PR DESCRIPTION
# Overview

- Remove dead `Logs` link on application homepage
- Alter docs pages links to new docs at `api.pocket.network/docs`
